### PR TITLE
Add basic optional logger class

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ instance as `received_logger`.
 ```ruby
 require 'optional_logger'
 
-logger = OptionalLogger.new(received_logger)
+logger = OptionalLogger::Logger.new(received_logger)
 
 logger.info("some info log message")
 logger.info("Program Name") { "some expensive info log message" }

--- a/lib/optional_logger.rb
+++ b/lib/optional_logger.rb
@@ -1,4 +1,5 @@
-require "optional_logger/version"
+require 'optional_logger/version'
+require 'optional_logger/logger'
 
 module OptionalLogger
   # Your code goes here...

--- a/lib/optional_logger/logger.rb
+++ b/lib/optional_logger/logger.rb
@@ -30,5 +30,9 @@ module OptionalLogger
     def fatal(progname_or_message = nil, &block)
       add(::Logger::FATAL, nil, progname_or_message, &block)
     end
+
+    def unknown(progname_or_message = nil, &block)
+      add(::Logger::UNKNOWN, nil, progname_or_message, &block)
+    end
   end
 end

--- a/lib/optional_logger/logger.rb
+++ b/lib/optional_logger/logger.rb
@@ -26,5 +26,9 @@ module OptionalLogger
     def error(progname_or_message = nil, &block)
       add(::Logger::ERROR, nil, progname_or_message, &block)
     end
+
+    def fatal(progname_or_message = nil, &block)
+      add(::Logger::FATAL, nil, progname_or_message, &block)
+    end
   end
 end

--- a/lib/optional_logger/logger.rb
+++ b/lib/optional_logger/logger.rb
@@ -14,5 +14,9 @@ module OptionalLogger
     def info(progname_or_message = nil, &block)
       add(::Logger::INFO, nil, progname_or_message, &block)
     end
+
+    def warn(progname_or_message = nil, &block)
+      add(::Logger::WARN, nil, progname_or_message, &block)
+    end
   end
 end

--- a/lib/optional_logger/logger.rb
+++ b/lib/optional_logger/logger.rb
@@ -7,5 +7,6 @@ module OptionalLogger
     def add(severity, message = nil, progname = nil, &block)
       @logger.add(severity, message, progname, &block) if @logger
     end
+    alias log add
   end
 end

--- a/lib/optional_logger/logger.rb
+++ b/lib/optional_logger/logger.rb
@@ -6,6 +6,10 @@ module OptionalLogger
       @logger = logger
     end
 
+    def wrapped_logger
+      @logger
+    end
+
     def add(severity, message = nil, progname = nil, &block)
       @logger.add(severity, message, progname, &block) if @logger
     end

--- a/lib/optional_logger/logger.rb
+++ b/lib/optional_logger/logger.rb
@@ -1,3 +1,5 @@
+require 'logger'
+
 module OptionalLogger
   class Logger
     def initialize(logger)
@@ -8,5 +10,9 @@ module OptionalLogger
       @logger.add(severity, message, progname, &block) if @logger
     end
     alias log add
+
+    def info(progname_or_message = nil, &block)
+      add(::Logger::INFO, nil, progname_or_message, &block)
+    end
   end
 end

--- a/lib/optional_logger/logger.rb
+++ b/lib/optional_logger/logger.rb
@@ -3,5 +3,9 @@ module OptionalLogger
     def initialize(logger)
       @logger = logger
     end
+
+    def add(severity, message = nil, progname = nil, &block)
+      @logger.add(severity, message, progname, &block) if @logger
+    end
   end
 end

--- a/lib/optional_logger/logger.rb
+++ b/lib/optional_logger/logger.rb
@@ -22,5 +22,9 @@ module OptionalLogger
     def debug(progname_or_message = nil, &block)
       add(::Logger::DEBUG, nil, progname_or_message, &block)
     end
+
+    def error(progname_or_message = nil, &block)
+      add(::Logger::ERROR, nil, progname_or_message, &block)
+    end
   end
 end

--- a/lib/optional_logger/logger.rb
+++ b/lib/optional_logger/logger.rb
@@ -18,5 +18,9 @@ module OptionalLogger
     def warn(progname_or_message = nil, &block)
       add(::Logger::WARN, nil, progname_or_message, &block)
     end
+
+    def debug(progname_or_message = nil, &block)
+      add(::Logger::DEBUG, nil, progname_or_message, &block)
+    end
   end
 end

--- a/lib/optional_logger/logger.rb
+++ b/lib/optional_logger/logger.rb
@@ -1,0 +1,7 @@
+module OptionalLogger
+  class Logger
+    def initialize(logger)
+      @logger = logger
+    end
+  end
+end

--- a/spec/optional_logger/logger_spec.rb
+++ b/spec/optional_logger/logger_spec.rb
@@ -56,14 +56,13 @@ RSpec.describe OptionalLogger::Logger do
     context 'when logger is NOT present' do
       subject { described_class.new(nil) }
 
-      it 'does NOT proxy #add to the logger #add' do
+      it 'does NOT proxy #add to the logger #add and therefore does not blow up' do
         severity = double('severity')
         message = double('message')
         progname = double('progname')
         block = Proc.new {}
 
-        expect(subject.instance_variable_get(:@logger)).not_to receive(:add)
-        subject.add(severity, message, progname, &block)
+        expect { subject.add(severity, message, progname, &block) }.not_to raise_error
       end
     end
   end

--- a/spec/optional_logger/logger_spec.rb
+++ b/spec/optional_logger/logger_spec.rb
@@ -163,4 +163,36 @@ RSpec.describe OptionalLogger::Logger do
       end
     end
   end
+
+  describe '#error' do
+    let(:logger) { double('logger') }
+    subject { described_class.new(logger) }
+
+    context 'when give a message' do
+      it 'logs the message as an error level message via #add' do
+        message = 'my test message'
+        expect(subject).to receive(:add).with(::Logger::ERROR, nil, message)
+        subject.error(message)
+      end
+    end
+
+    context 'when given a block' do
+      it 'logs the yielded value from the block with a nil progname' do
+        message = 'my block test message'
+        block = Proc.new { message }
+        expect(subject).to receive(:add).with(::Logger::ERROR, nil, nil, &block)
+        subject.error(&block)
+      end
+    end
+
+    context 'when given a block and progname' do
+      it 'logs the yielded value from the block with the progname' do
+        message = 'my block test message'
+        progname = 'my progname'
+        block = Proc.new { message }
+        expect(subject).to receive(:add).with(::Logger::ERROR, nil, progname, &block)
+        subject.error(progname, &block)
+      end
+    end
+  end
 end

--- a/spec/optional_logger/logger_spec.rb
+++ b/spec/optional_logger/logger_spec.rb
@@ -16,6 +16,26 @@ RSpec.describe OptionalLogger::Logger do
     end
   end
 
+  describe '#wrapped_logger' do
+    context 'when the optional logger was constructed with a logger' do
+      let(:logger) { double('logger') }
+      subject { described_class.new(logger) }
+
+      it 'returns the logger it was constructed with' do
+        expect(subject.wrapped_logger).to eq(logger)
+      end
+    end
+
+    context 'when the optional laggor was constructed with a nil' do
+      let(:logger) { nil }
+      subject { described_class.new(logger) }
+
+      it 'returns nil' do
+        expect(subject.wrapped_logger).to be_nil
+      end
+    end
+  end
+
   describe '#add' do
     context 'when logger is present' do
       let(:logger) { double('logger') }

--- a/spec/optional_logger/logger_spec.rb
+++ b/spec/optional_logger/logger_spec.rb
@@ -15,4 +15,56 @@ RSpec.describe OptionalLogger::Logger do
       expect(optional_logger.instance_variable_get(:@logger)).to eq(logger)
     end
   end
+
+  describe '#add' do
+    context 'when logger is present' do
+      let(:logger) { double('logger') }
+      subject { described_class.new(logger) }
+
+      it 'proxies #add to the logger #add' do
+        severity = double('severity')
+        message = double('message')
+        progname = double('progname')
+        block = Proc.new {}
+
+        expect(logger).to receive(:add).with(severity, message, progname, &block)
+        subject.add(severity, message, progname, &block)
+      end
+
+      context 'when progname is not passed' do
+        it 'proxies #add to the logger #add with progname as nil' do
+          severity = double('severity')
+          message = double('message')
+          block = Proc.new {}
+
+          expect(logger).to receive(:add).with(severity, message, nil, &block)
+          subject.add(severity, message, &block)
+        end
+      end
+
+      context 'when progname and message are not passed' do
+        it 'proxies #add to the logger #add with progname and message as nil' do
+          severity = double('severity')
+          block = Proc.new {}
+
+          expect(logger).to receive(:add).with(severity, nil, nil, &block)
+          subject.add(severity, &block)
+        end
+      end
+    end
+
+    context 'when logger is NOT present' do
+      subject { described_class.new(nil) }
+
+      it 'does NOT proxy #add to the logger #add' do
+        severity = double('severity')
+        message = double('message')
+        progname = double('progname')
+        block = Proc.new {}
+
+        expect(subject.instance_variable_get(:@logger)).not_to receive(:add)
+        subject.add(severity, message, progname, &block)
+      end
+    end
+  end
 end

--- a/spec/optional_logger/logger_spec.rb
+++ b/spec/optional_logger/logger_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe OptionalLogger::Logger do
-  describe '#new' do
+  describe '.new' do
     subject { described_class }
 
     it 'constructs an instance of the optional logger' do

--- a/spec/optional_logger/logger_spec.rb
+++ b/spec/optional_logger/logger_spec.rb
@@ -131,4 +131,36 @@ RSpec.describe OptionalLogger::Logger do
       end
     end
   end
+
+  describe '#debug' do
+    let(:logger) { double('logger') }
+    subject { described_class.new(logger) }
+
+    context 'when give a message' do
+      it 'logs the message as an debug level message via #add' do
+        message = 'my test message'
+        expect(subject).to receive(:add).with(::Logger::DEBUG, nil, message)
+        subject.debug(message)
+      end
+    end
+
+    context 'when given a block' do
+      it 'logs the yielded value from the block with a nil progname' do
+        message = 'my block test message'
+        block = Proc.new { message }
+        expect(subject).to receive(:add).with(::Logger::DEBUG, nil, nil, &block)
+        subject.debug(&block)
+      end
+    end
+
+    context 'when given a block and progname' do
+      it 'logs the yielded value from the block with the progname' do
+        message = 'my block test message'
+        progname = 'my progname'
+        block = Proc.new { message }
+        expect(subject).to receive(:add).with(::Logger::DEBUG, nil, progname, &block)
+        subject.debug(progname, &block)
+      end
+    end
+  end
 end

--- a/spec/optional_logger/logger_spec.rb
+++ b/spec/optional_logger/logger_spec.rb
@@ -67,4 +67,36 @@ RSpec.describe OptionalLogger::Logger do
       end
     end
   end
+
+  describe '#info' do
+    let(:logger) { double('logger') }
+    subject { described_class.new(logger) }
+
+    context 'when give a message' do
+      it 'logs the message as an info level message via #add' do
+        message = 'my test message'
+        expect(subject).to receive(:add).with(::Logger::INFO, nil, message)
+        subject.info(message)
+      end
+    end
+
+    context 'when given a block' do
+      it 'logs the yielded value from the block with a nil progname' do
+        message = 'my block test message'
+        block = Proc.new { message }
+        expect(subject).to receive(:add).with(::Logger::INFO, nil, nil, &block)
+        subject.info(&block)
+      end
+    end
+
+    context 'when given a block and progname' do
+      it 'logs the yielded value from the block with the progname' do
+        message = 'my block test message'
+        progname = 'my progname'
+        block = Proc.new { message }
+        expect(subject).to receive(:add).with(::Logger::INFO, nil, progname, &block)
+        subject.info(progname, &block)
+      end
+    end
+  end
 end

--- a/spec/optional_logger/logger_spec.rb
+++ b/spec/optional_logger/logger_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+RSpec.describe OptionalLogger::Logger do
+  describe '#new' do
+    subject { described_class }
+
+    it 'constructs an instance of the optional logger' do
+      optional_logger = subject.new(double)
+      expect(optional_logger).to be_a(OptionalLogger::Logger)
+    end
+
+    it 'stores the provided logger in an instance variable' do
+      logger = double
+      optional_logger = subject.new(logger)
+      expect(optional_logger.instance_variable_get(:@logger)).to eq(logger)
+    end
+  end
+end

--- a/spec/optional_logger/logger_spec.rb
+++ b/spec/optional_logger/logger_spec.rb
@@ -227,4 +227,36 @@ RSpec.describe OptionalLogger::Logger do
       end
     end
   end
+
+  describe '#unknown' do
+    let(:logger) { double('logger') }
+    subject { described_class.new(logger) }
+
+    context 'when give a message' do
+      it 'logs the message as an unknown level message via #add' do
+        message = 'my test message'
+        expect(subject).to receive(:add).with(::Logger::UNKNOWN, nil, message)
+        subject.unknown(message)
+      end
+    end
+
+    context 'when given a block' do
+      it 'logs the yielded value from the block with a nil progname' do
+        message = 'my block test message'
+        block = Proc.new { message }
+        expect(subject).to receive(:add).with(::Logger::UNKNOWN, nil, nil, &block)
+        subject.unknown(&block)
+      end
+    end
+
+    context 'when given a block and progname' do
+      it 'logs the yielded value from the block with the progname' do
+        message = 'my block test message'
+        progname = 'my progname'
+        block = Proc.new { message }
+        expect(subject).to receive(:add).with(::Logger::UNKNOWN, nil, progname, &block)
+        subject.unknown(progname, &block)
+      end
+    end
+  end
 end

--- a/spec/optional_logger/logger_spec.rb
+++ b/spec/optional_logger/logger_spec.rb
@@ -72,31 +72,11 @@ RSpec.describe OptionalLogger::Logger do
     let(:logger) { double('logger') }
     subject { described_class.new(logger) }
 
-    context 'when give a message' do
-      it 'logs the message as an info level message via #add' do
-        message = 'my test message'
-        expect(subject).to receive(:add).with(::Logger::INFO, nil, message)
-        subject.info(message)
-      end
-    end
-
-    context 'when given a block' do
-      it 'logs the yielded value from the block with a nil progname' do
-        message = 'my block test message'
-        block = Proc.new { message }
-        expect(subject).to receive(:add).with(::Logger::INFO, nil, nil, &block)
-        subject.info(&block)
-      end
-    end
-
-    context 'when given a block and progname' do
-      it 'logs the yielded value from the block with the progname' do
-        message = 'my block test message'
-        progname = 'my progname'
-        block = Proc.new { message }
-        expect(subject).to receive(:add).with(::Logger::INFO, nil, progname, &block)
-        subject.info(progname, &block)
-      end
+    it 'calls the add method appropriately' do
+      message = 'my test message'
+      block = Proc.new { }
+      expect(subject).to receive(:add).with(::Logger::INFO, nil, message, &block)
+      subject.info(message, &block)
     end
   end
 
@@ -104,31 +84,11 @@ RSpec.describe OptionalLogger::Logger do
     let(:logger) { double('logger') }
     subject { described_class.new(logger) }
 
-    context 'when give a message' do
-      it 'logs the message as an warn level message via #add' do
-        message = 'my test message'
-        expect(subject).to receive(:add).with(::Logger::WARN, nil, message)
-        subject.warn(message)
-      end
-    end
-
-    context 'when given a block' do
-      it 'logs the yielded value from the block with a nil progname' do
-        message = 'my block test message'
-        block = Proc.new { message }
-        expect(subject).to receive(:add).with(::Logger::WARN, nil, nil, &block)
-        subject.warn(&block)
-      end
-    end
-
-    context 'when given a block and progname' do
-      it 'logs the yielded value from the block with the progname' do
-        message = 'my block test message'
-        progname = 'my progname'
-        block = Proc.new { message }
-        expect(subject).to receive(:add).with(::Logger::WARN, nil, progname, &block)
-        subject.warn(progname, &block)
-      end
+    it 'calls the add method appropriately' do
+      message = 'my test message'
+      block = Proc.new { }
+      expect(subject).to receive(:add).with(::Logger::WARN, nil, message, &block)
+      subject.warn(message, &block)
     end
   end
 
@@ -136,31 +96,11 @@ RSpec.describe OptionalLogger::Logger do
     let(:logger) { double('logger') }
     subject { described_class.new(logger) }
 
-    context 'when give a message' do
-      it 'logs the message as an debug level message via #add' do
-        message = 'my test message'
-        expect(subject).to receive(:add).with(::Logger::DEBUG, nil, message)
-        subject.debug(message)
-      end
-    end
-
-    context 'when given a block' do
-      it 'logs the yielded value from the block with a nil progname' do
-        message = 'my block test message'
-        block = Proc.new { message }
-        expect(subject).to receive(:add).with(::Logger::DEBUG, nil, nil, &block)
-        subject.debug(&block)
-      end
-    end
-
-    context 'when given a block and progname' do
-      it 'logs the yielded value from the block with the progname' do
-        message = 'my block test message'
-        progname = 'my progname'
-        block = Proc.new { message }
-        expect(subject).to receive(:add).with(::Logger::DEBUG, nil, progname, &block)
-        subject.debug(progname, &block)
-      end
+    it 'calls the add method appropriately' do
+      message = 'my test message'
+      block = Proc.new { }
+      expect(subject).to receive(:add).with(::Logger::DEBUG, nil, message, &block)
+      subject.debug(message, &block)
     end
   end
 
@@ -168,31 +108,11 @@ RSpec.describe OptionalLogger::Logger do
     let(:logger) { double('logger') }
     subject { described_class.new(logger) }
 
-    context 'when give a message' do
-      it 'logs the message as an error level message via #add' do
-        message = 'my test message'
-        expect(subject).to receive(:add).with(::Logger::ERROR, nil, message)
-        subject.error(message)
-      end
-    end
-
-    context 'when given a block' do
-      it 'logs the yielded value from the block with a nil progname' do
-        message = 'my block test message'
-        block = Proc.new { message }
-        expect(subject).to receive(:add).with(::Logger::ERROR, nil, nil, &block)
-        subject.error(&block)
-      end
-    end
-
-    context 'when given a block and progname' do
-      it 'logs the yielded value from the block with the progname' do
-        message = 'my block test message'
-        progname = 'my progname'
-        block = Proc.new { message }
-        expect(subject).to receive(:add).with(::Logger::ERROR, nil, progname, &block)
-        subject.error(progname, &block)
-      end
+    it 'calls the add method appropriately' do
+      message = 'my test message'
+      block = Proc.new { }
+      expect(subject).to receive(:add).with(::Logger::ERROR, nil, message, &block)
+      subject.error(message, &block)
     end
   end
 
@@ -200,31 +120,11 @@ RSpec.describe OptionalLogger::Logger do
     let(:logger) { double('logger') }
     subject { described_class.new(logger) }
 
-    context 'when give a message' do
-      it 'logs the message as an fatal level message via #add' do
-        message = 'my test message'
-        expect(subject).to receive(:add).with(::Logger::FATAL, nil, message)
-        subject.fatal(message)
-      end
-    end
-
-    context 'when given a block' do
-      it 'logs the yielded value from the block with a nil progname' do
-        message = 'my block test message'
-        block = Proc.new { message }
-        expect(subject).to receive(:add).with(::Logger::FATAL, nil, nil, &block)
-        subject.fatal(&block)
-      end
-    end
-
-    context 'when given a block and progname' do
-      it 'logs the yielded value from the block with the progname' do
-        message = 'my block test message'
-        progname = 'my progname'
-        block = Proc.new { message }
-        expect(subject).to receive(:add).with(::Logger::FATAL, nil, progname, &block)
-        subject.fatal(progname, &block)
-      end
+    it 'calls the add method appropriately' do
+      message = 'my test message'
+      block = Proc.new { }
+      expect(subject).to receive(:add).with(::Logger::FATAL, nil, message, &block)
+      subject.fatal(message, &block)
     end
   end
 
@@ -232,31 +132,11 @@ RSpec.describe OptionalLogger::Logger do
     let(:logger) { double('logger') }
     subject { described_class.new(logger) }
 
-    context 'when give a message' do
-      it 'logs the message as an unknown level message via #add' do
-        message = 'my test message'
-        expect(subject).to receive(:add).with(::Logger::UNKNOWN, nil, message)
-        subject.unknown(message)
-      end
-    end
-
-    context 'when given a block' do
-      it 'logs the yielded value from the block with a nil progname' do
-        message = 'my block test message'
-        block = Proc.new { message }
-        expect(subject).to receive(:add).with(::Logger::UNKNOWN, nil, nil, &block)
-        subject.unknown(&block)
-      end
-    end
-
-    context 'when given a block and progname' do
-      it 'logs the yielded value from the block with the progname' do
-        message = 'my block test message'
-        progname = 'my progname'
-        block = Proc.new { message }
-        expect(subject).to receive(:add).with(::Logger::UNKNOWN, nil, progname, &block)
-        subject.unknown(progname, &block)
-      end
+    it 'calls the add method appropriately' do
+      message = 'my test message'
+      block = Proc.new { }
+      expect(subject).to receive(:add).with(::Logger::UNKNOWN, nil, message, &block)
+      subject.unknown(message, &block)
     end
   end
 end

--- a/spec/optional_logger/logger_spec.rb
+++ b/spec/optional_logger/logger_spec.rb
@@ -99,4 +99,36 @@ RSpec.describe OptionalLogger::Logger do
       end
     end
   end
+
+  describe '#warn' do
+    let(:logger) { double('logger') }
+    subject { described_class.new(logger) }
+
+    context 'when give a message' do
+      it 'logs the message as an warn level message via #add' do
+        message = 'my test message'
+        expect(subject).to receive(:add).with(::Logger::WARN, nil, message)
+        subject.warn(message)
+      end
+    end
+
+    context 'when given a block' do
+      it 'logs the yielded value from the block with a nil progname' do
+        message = 'my block test message'
+        block = Proc.new { message }
+        expect(subject).to receive(:add).with(::Logger::WARN, nil, nil, &block)
+        subject.warn(&block)
+      end
+    end
+
+    context 'when given a block and progname' do
+      it 'logs the yielded value from the block with the progname' do
+        message = 'my block test message'
+        progname = 'my progname'
+        block = Proc.new { message }
+        expect(subject).to receive(:add).with(::Logger::WARN, nil, progname, &block)
+        subject.warn(progname, &block)
+      end
+    end
+  end
 end

--- a/spec/optional_logger/logger_spec.rb
+++ b/spec/optional_logger/logger_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe OptionalLogger::Logger do
       end
     end
 
-    context 'when the optional laggor was constructed with a nil' do
+    context 'when the optional logger was constructed with a nil' do
       let(:logger) { nil }
       subject { described_class.new(logger) }
 

--- a/spec/optional_logger/logger_spec.rb
+++ b/spec/optional_logger/logger_spec.rb
@@ -195,4 +195,36 @@ RSpec.describe OptionalLogger::Logger do
       end
     end
   end
+
+  describe '#fatal' do
+    let(:logger) { double('logger') }
+    subject { described_class.new(logger) }
+
+    context 'when give a message' do
+      it 'logs the message as an fatal level message via #add' do
+        message = 'my test message'
+        expect(subject).to receive(:add).with(::Logger::FATAL, nil, message)
+        subject.fatal(message)
+      end
+    end
+
+    context 'when given a block' do
+      it 'logs the yielded value from the block with a nil progname' do
+        message = 'my block test message'
+        block = Proc.new { message }
+        expect(subject).to receive(:add).with(::Logger::FATAL, nil, nil, &block)
+        subject.fatal(&block)
+      end
+    end
+
+    context 'when given a block and progname' do
+      it 'logs the yielded value from the block with the progname' do
+        message = 'my block test message'
+        progname = 'my progname'
+        block = Proc.new { message }
+        expect(subject).to receive(:add).with(::Logger::FATAL, nil, progname, &block)
+        subject.fatal(progname, &block)
+      end
+    end
+  end
 end

--- a/spec/optional_logger_spec.rb
+++ b/spec/optional_logger_spec.rb
@@ -66,127 +66,168 @@ describe OptionalLogger do
         expect(log_content.read).to match(/INFO -- : my message$/)
       end
     end
+  end
 
-    describe '#warn' do
-      context 'when given a block' do
-        context 'when given progname' do
-          it 'logs an warn severity level message' do
-            log_content = StringIO.new
-            message = 'my test message'
-            block = Proc.new { message }
-            logger = ::Logger.new(log_content)
-            optional_logger = OptionalLogger::Logger.new(logger)
-            optional_logger.warn('my progname', &block)
-            log_content.rewind
-            expect(log_content.read).to match(/WARN -- my progname: my test message$/)
-          end
-        end
-
-        context 'when NOT given progname' do
-          it 'logs an warn severity level message' do
-            log_content = StringIO.new
-            message = 'my test message'
-            block = Proc.new { message }
-            logger = ::Logger.new(log_content)
-            optional_logger = OptionalLogger::Logger.new(logger)
-            optional_logger.warn(&block)
-            log_content.rewind
-            expect(log_content.read).to match(/WARN -- : my test message$/)
-          end
-        end
-      end
-
-      context 'when not given a block' do
+  describe '#warn' do
+    context 'when given a block' do
+      context 'when given progname' do
         it 'logs an warn severity level message' do
           log_content = StringIO.new
+          message = 'my test message'
+          block = Proc.new { message }
           logger = ::Logger.new(log_content)
           optional_logger = OptionalLogger::Logger.new(logger)
-          optional_logger.warn('my message')
+          optional_logger.warn('my progname', &block)
           log_content.rewind
-          expect(log_content.read).to match(/WARN -- : my message$/)
+          expect(log_content.read).to match(/WARN -- my progname: my test message$/)
+        end
+      end
+
+      context 'when NOT given progname' do
+        it 'logs an warn severity level message' do
+          log_content = StringIO.new
+          message = 'my test message'
+          block = Proc.new { message }
+          logger = ::Logger.new(log_content)
+          optional_logger = OptionalLogger::Logger.new(logger)
+          optional_logger.warn(&block)
+          log_content.rewind
+          expect(log_content.read).to match(/WARN -- : my test message$/)
         end
       end
     end
 
-    describe '#debug' do
-      context 'when given a block' do
-        context 'when given progname' do
-          it 'logs an debug severity level message' do
-            log_content = StringIO.new
-            message = 'my test message'
-            block = Proc.new { message }
-            logger = ::Logger.new(log_content)
-            optional_logger = OptionalLogger::Logger.new(logger)
-            optional_logger.debug('my progname', &block)
-            log_content.rewind
-            expect(log_content.read).to match(/DEBUG -- my progname: my test message$/)
-          end
-        end
-
-        context 'when NOT given progname' do
-          it 'logs an debug severity level message' do
-            log_content = StringIO.new
-            message = 'my test message'
-            block = Proc.new { message }
-            logger = ::Logger.new(log_content)
-            optional_logger = OptionalLogger::Logger.new(logger)
-            optional_logger.debug(&block)
-            log_content.rewind
-            expect(log_content.read).to match(/DEBUG -- : my test message$/)
-          end
-        end
+    context 'when not given a block' do
+      it 'logs an warn severity level message' do
+        log_content = StringIO.new
+        logger = ::Logger.new(log_content)
+        optional_logger = OptionalLogger::Logger.new(logger)
+        optional_logger.warn('my message')
+        log_content.rewind
+        expect(log_content.read).to match(/WARN -- : my message$/)
       end
+    end
+  end
 
-      context 'when not given a block' do
+  describe '#debug' do
+    context 'when given a block' do
+      context 'when given progname' do
         it 'logs an debug severity level message' do
           log_content = StringIO.new
+          message = 'my test message'
+          block = Proc.new { message }
           logger = ::Logger.new(log_content)
           optional_logger = OptionalLogger::Logger.new(logger)
-          optional_logger.debug('my message')
+          optional_logger.debug('my progname', &block)
           log_content.rewind
-          expect(log_content.read).to match(/DEBUG -- : my message$/)
+          expect(log_content.read).to match(/DEBUG -- my progname: my test message$/)
+        end
+      end
+
+      context 'when NOT given progname' do
+        it 'logs an debug severity level message' do
+          log_content = StringIO.new
+          message = 'my test message'
+          block = Proc.new { message }
+          logger = ::Logger.new(log_content)
+          optional_logger = OptionalLogger::Logger.new(logger)
+          optional_logger.debug(&block)
+          log_content.rewind
+          expect(log_content.read).to match(/DEBUG -- : my test message$/)
         end
       end
     end
 
-    describe '#error' do
-      context 'when given a block' do
-        context 'when given progname' do
-          it 'logs an error severity level message' do
-            log_content = StringIO.new
-            message = 'my test message'
-            block = Proc.new { message }
-            logger = ::Logger.new(log_content)
-            optional_logger = OptionalLogger::Logger.new(logger)
-            optional_logger.error('my progname', &block)
-            log_content.rewind
-            expect(log_content.read).to match(/ERROR -- my progname: my test message$/)
-          end
-        end
+    context 'when not given a block' do
+      it 'logs an debug severity level message' do
+        log_content = StringIO.new
+        logger = ::Logger.new(log_content)
+        optional_logger = OptionalLogger::Logger.new(logger)
+        optional_logger.debug('my message')
+        log_content.rewind
+        expect(log_content.read).to match(/DEBUG -- : my message$/)
+      end
+    end
+  end
 
-        context 'when NOT given progname' do
-          it 'logs an error severity level message' do
-            log_content = StringIO.new
-            message = 'my test message'
-            block = Proc.new { message }
-            logger = ::Logger.new(log_content)
-            optional_logger = OptionalLogger::Logger.new(logger)
-            optional_logger.error(&block)
-            log_content.rewind
-            expect(log_content.read).to match(/ERROR -- : my test message$/)
-          end
+  describe '#error' do
+    context 'when given a block' do
+      context 'when given progname' do
+        it 'logs an error severity level message' do
+          log_content = StringIO.new
+          message = 'my test message'
+          block = Proc.new { message }
+          logger = ::Logger.new(log_content)
+          optional_logger = OptionalLogger::Logger.new(logger)
+          optional_logger.error('my progname', &block)
+          log_content.rewind
+          expect(log_content.read).to match(/ERROR -- my progname: my test message$/)
         end
       end
 
-      context 'when not given a block' do
+      context 'when NOT given progname' do
         it 'logs an error severity level message' do
           log_content = StringIO.new
+          message = 'my test message'
+          block = Proc.new { message }
           logger = ::Logger.new(log_content)
           optional_logger = OptionalLogger::Logger.new(logger)
-          optional_logger.error('my message')
+          optional_logger.error(&block)
           log_content.rewind
-          expect(log_content.read).to match(/ERROR -- : my message$/)
+          expect(log_content.read).to match(/ERROR -- : my test message$/)
         end
+      end
+    end
+
+    context 'when not given a block' do
+      it 'logs an error severity level message' do
+        log_content = StringIO.new
+        logger = ::Logger.new(log_content)
+        optional_logger = OptionalLogger::Logger.new(logger)
+        optional_logger.error('my message')
+        log_content.rewind
+        expect(log_content.read).to match(/ERROR -- : my message$/)
+      end
+    end
+  end
+
+  describe '#fatal' do
+    context 'when given a block' do
+      context 'when given progname' do
+        it 'logs an fatal severity level message' do
+          log_content = StringIO.new
+          message = 'my test message'
+          block = Proc.new { message }
+          logger = ::Logger.new(log_content)
+          optional_logger = OptionalLogger::Logger.new(logger)
+          optional_logger.fatal('my progname', &block)
+          log_content.rewind
+          expect(log_content.read).to match(/FATAL -- my progname: my test message$/)
+        end
+      end
+
+      context 'when NOT given progname' do
+        it 'logs an fatal severity level message' do
+          log_content = StringIO.new
+          message = 'my test message'
+          block = Proc.new { message }
+          logger = ::Logger.new(log_content)
+          optional_logger = OptionalLogger::Logger.new(logger)
+          optional_logger.fatal(&block)
+          log_content.rewind
+          expect(log_content.read).to match(/FATAL -- : my test message$/)
+        end
+      end
+    end
+
+    context 'when not given a block' do
+      it 'logs an fatal severity level message' do
+        log_content = StringIO.new
+        logger = ::Logger.new(log_content)
+        optional_logger = OptionalLogger::Logger.new(logger)
+        optional_logger.fatal('my message')
+        log_content.rewind
+        expect(log_content.read).to match(/FATAL -- : my message$/)
       end
     end
   end

--- a/spec/optional_logger_spec.rb
+++ b/spec/optional_logger_spec.rb
@@ -107,5 +107,46 @@ describe OptionalLogger do
         end
       end
     end
+
+    describe '#debug' do
+      context 'when given a block' do
+        context 'when given progname' do
+          it 'logs an debug severity level message' do
+            log_content = StringIO.new
+            message = 'my test message'
+            block = Proc.new { message }
+            logger = ::Logger.new(log_content)
+            optional_logger = OptionalLogger::Logger.new(logger)
+            optional_logger.debug('my progname', &block)
+            log_content.rewind
+            expect(log_content.read).to match(/DEBUG -- my progname: my test message$/)
+          end
+        end
+
+        context 'when NOT given progname' do
+          it 'logs an debug severity level message' do
+            log_content = StringIO.new
+            message = 'my test message'
+            block = Proc.new { message }
+            logger = ::Logger.new(log_content)
+            optional_logger = OptionalLogger::Logger.new(logger)
+            optional_logger.debug(&block)
+            log_content.rewind
+            expect(log_content.read).to match(/DEBUG -- : my test message$/)
+          end
+        end
+      end
+
+      context 'when not given a block' do
+        it 'logs an debug severity level message' do
+          log_content = StringIO.new
+          logger = ::Logger.new(log_content)
+          optional_logger = OptionalLogger::Logger.new(logger)
+          optional_logger.debug('my message')
+          log_content.rewind
+          expect(log_content.read).to match(/DEBUG -- : my message$/)
+        end
+      end
+    end
   end
 end

--- a/spec/optional_logger_spec.rb
+++ b/spec/optional_logger_spec.rb
@@ -66,5 +66,46 @@ describe OptionalLogger do
         expect(log_content.read).to match(/INFO -- : my message$/)
       end
     end
+
+    describe '#warn' do
+      context 'when given a block' do
+        context 'when given progname' do
+          it 'logs an warn severity level message' do
+            log_content = StringIO.new
+            message = 'my test message'
+            block = Proc.new { message }
+            logger = ::Logger.new(log_content)
+            optional_logger = OptionalLogger::Logger.new(logger)
+            optional_logger.warn('my progname', &block)
+            log_content.rewind
+            expect(log_content.read).to match(/WARN -- my progname: my test message$/)
+          end
+        end
+
+        context 'when NOT given progname' do
+          it 'logs an warn severity level message' do
+            log_content = StringIO.new
+            message = 'my test message'
+            block = Proc.new { message }
+            logger = ::Logger.new(log_content)
+            optional_logger = OptionalLogger::Logger.new(logger)
+            optional_logger.warn(&block)
+            log_content.rewind
+            expect(log_content.read).to match(/WARN -- : my test message$/)
+          end
+        end
+      end
+
+      context 'when not given a block' do
+        it 'logs an warn severity level message' do
+          log_content = StringIO.new
+          logger = ::Logger.new(log_content)
+          optional_logger = OptionalLogger::Logger.new(logger)
+          optional_logger.warn('my message')
+          log_content.rewind
+          expect(log_content.read).to match(/WARN -- : my message$/)
+        end
+      end
+    end
   end
 end

--- a/spec/optional_logger_spec.rb
+++ b/spec/optional_logger_spec.rb
@@ -1,7 +1,16 @@
-require "spec_helper"
+require 'spec_helper'
 
 describe OptionalLogger do
-  it "has a version number" do
+  it 'has a version number' do
     expect(OptionalLogger::VERSION).not_to be nil
+  end
+
+  it 'add log message to log' do
+    log_content = StringIO.new
+    logger = Logger.new(log_content)
+    optional_logger = OptionalLogger::Logger.new(logger)
+    optional_logger.add(Logger::INFO, 'my message', 'my prog')
+    log_content.rewind
+    expect(log_content.read).to match(/INFO -- my prog: my message$/)
   end
 end

--- a/spec/optional_logger_spec.rb
+++ b/spec/optional_logger_spec.rb
@@ -13,4 +13,13 @@ describe OptionalLogger do
     log_content.rewind
     expect(log_content.read).to match(/INFO -- my prog: my message$/)
   end
+
+  it 'add log message to log' do
+    log_content = StringIO.new
+    logger = Logger.new(log_content)
+    optional_logger = OptionalLogger::Logger.new(logger)
+    optional_logger.log(Logger::INFO, 'my message', 'my prog')
+    log_content.rewind
+    expect(log_content.read).to match(/INFO -- my prog: my message$/)
+  end
 end

--- a/spec/optional_logger_spec.rb
+++ b/spec/optional_logger_spec.rb
@@ -231,4 +231,45 @@ describe OptionalLogger do
       end
     end
   end
+
+  describe '#unknown' do
+    context 'when given a block' do
+      context 'when given progname' do
+        it 'logs an unknown severity level message' do
+          log_content = StringIO.new
+          message = 'my test message'
+          block = Proc.new { message }
+          logger = ::Logger.new(log_content)
+          optional_logger = OptionalLogger::Logger.new(logger)
+          optional_logger.unknown('my progname', &block)
+          log_content.rewind
+          expect(log_content.read).to match(/ANY -- my progname: my test message$/)
+        end
+      end
+
+      context 'when NOT given progname' do
+        it 'logs an unknown severity level message' do
+          log_content = StringIO.new
+          message = 'my test message'
+          block = Proc.new { message }
+          logger = ::Logger.new(log_content)
+          optional_logger = OptionalLogger::Logger.new(logger)
+          optional_logger.unknown(&block)
+          log_content.rewind
+          expect(log_content.read).to match(/ANY -- : my test message$/)
+        end
+      end
+    end
+
+    context 'when not given a block' do
+      it 'logs an unknown severity level message' do
+        log_content = StringIO.new
+        logger = ::Logger.new(log_content)
+        optional_logger = OptionalLogger::Logger.new(logger)
+        optional_logger.unknown('my message')
+        log_content.rewind
+        expect(log_content.read).to match(/ANY -- : my message$/)
+      end
+    end
+  end
 end

--- a/spec/optional_logger_spec.rb
+++ b/spec/optional_logger_spec.rb
@@ -5,6 +5,24 @@ describe OptionalLogger do
     expect(OptionalLogger::VERSION).not_to be nil
   end
 
+  describe '.new' do
+    it 'constructs a new OptionalLogger::Logger instance' do
+      log_content = StringIO.new
+      logger = ::Logger.new(log_content)
+      optional_logger = OptionalLogger::Logger.new(logger)
+      expect(optional_logger).to be_a(OptionalLogger::Logger)
+    end
+  end
+
+  describe '#wrapped_logger' do
+    it 'returns the logger it was constructed with' do
+      log_content = StringIO.new
+      logger = ::Logger.new(log_content)
+      optional_logger = OptionalLogger::Logger.new(logger)
+      expect(optional_logger.wrapped_logger).to eq(logger)
+    end
+  end
+
   describe '#add' do
     context 'when given message' do
       context 'when given progname' do

--- a/spec/optional_logger_spec.rb
+++ b/spec/optional_logger_spec.rb
@@ -148,5 +148,46 @@ describe OptionalLogger do
         end
       end
     end
+
+    describe '#error' do
+      context 'when given a block' do
+        context 'when given progname' do
+          it 'logs an error severity level message' do
+            log_content = StringIO.new
+            message = 'my test message'
+            block = Proc.new { message }
+            logger = ::Logger.new(log_content)
+            optional_logger = OptionalLogger::Logger.new(logger)
+            optional_logger.error('my progname', &block)
+            log_content.rewind
+            expect(log_content.read).to match(/ERROR -- my progname: my test message$/)
+          end
+        end
+
+        context 'when NOT given progname' do
+          it 'logs an error severity level message' do
+            log_content = StringIO.new
+            message = 'my test message'
+            block = Proc.new { message }
+            logger = ::Logger.new(log_content)
+            optional_logger = OptionalLogger::Logger.new(logger)
+            optional_logger.error(&block)
+            log_content.rewind
+            expect(log_content.read).to match(/ERROR -- : my test message$/)
+          end
+        end
+      end
+
+      context 'when not given a block' do
+        it 'logs an error severity level message' do
+          log_content = StringIO.new
+          logger = ::Logger.new(log_content)
+          optional_logger = OptionalLogger::Logger.new(logger)
+          optional_logger.error('my message')
+          log_content.rewind
+          expect(log_content.read).to match(/ERROR -- : my message$/)
+        end
+      end
+    end
   end
 end

--- a/spec/optional_logger_spec.rb
+++ b/spec/optional_logger_spec.rb
@@ -5,21 +5,66 @@ describe OptionalLogger do
     expect(OptionalLogger::VERSION).not_to be nil
   end
 
-  it 'add log message to log' do
-    log_content = StringIO.new
-    logger = Logger.new(log_content)
-    optional_logger = OptionalLogger::Logger.new(logger)
-    optional_logger.add(Logger::INFO, 'my message', 'my prog')
-    log_content.rewind
-    expect(log_content.read).to match(/INFO -- my prog: my message$/)
+  describe '#add' do
+    it 'add log message to log' do
+      log_content = StringIO.new
+      logger = ::Logger.new(log_content)
+      optional_logger = OptionalLogger::Logger.new(logger)
+      optional_logger.add(::Logger::INFO, 'my message', 'my prog')
+      log_content.rewind
+      expect(log_content.read).to match(/INFO -- my prog: my message$/)
+    end
   end
 
-  it 'add log message to log' do
-    log_content = StringIO.new
-    logger = Logger.new(log_content)
-    optional_logger = OptionalLogger::Logger.new(logger)
-    optional_logger.log(Logger::INFO, 'my message', 'my prog')
-    log_content.rewind
-    expect(log_content.read).to match(/INFO -- my prog: my message$/)
+  describe '#log' do
+    it 'add log message to log using' do
+      log_content = StringIO.new
+      logger = ::Logger.new(log_content)
+      optional_logger = OptionalLogger::Logger.new(logger)
+      optional_logger.log(::Logger::INFO, 'my message', 'my prog')
+      log_content.rewind
+      expect(log_content.read).to match(/INFO -- my prog: my message$/)
+    end
+  end
+
+  describe '#info' do
+    context 'when given a block' do
+      context 'when given progname' do
+        it 'logs an info severity level message' do
+          log_content = StringIO.new
+          message = 'my test message'
+          block = Proc.new { message }
+          logger = ::Logger.new(log_content)
+          optional_logger = OptionalLogger::Logger.new(logger)
+          optional_logger.info('my progname', &block)
+          log_content.rewind
+          expect(log_content.read).to match(/INFO -- my progname: my test message$/)
+        end
+      end
+
+      context 'when NOT given progname' do
+        it 'logs an info severity level message' do
+          log_content = StringIO.new
+          message = 'my test message'
+          block = Proc.new { message }
+          logger = ::Logger.new(log_content)
+          optional_logger = OptionalLogger::Logger.new(logger)
+          optional_logger.info(&block)
+          log_content.rewind
+          expect(log_content.read).to match(/INFO -- : my test message$/)
+        end
+      end
+    end
+
+    context 'when not given a block' do
+      it 'logs an info severity level message' do
+        log_content = StringIO.new
+        logger = ::Logger.new(log_content)
+        optional_logger = OptionalLogger::Logger.new(logger)
+        optional_logger.info('my message')
+        log_content.rewind
+        expect(log_content.read).to match(/INFO -- : my message$/)
+      end
+    end
   end
 end

--- a/spec/optional_logger_spec.rb
+++ b/spec/optional_logger_spec.rb
@@ -6,13 +6,93 @@ describe OptionalLogger do
   end
 
   describe '#add' do
-    it 'add log message to log' do
-      log_content = StringIO.new
-      logger = ::Logger.new(log_content)
-      optional_logger = OptionalLogger::Logger.new(logger)
-      optional_logger.add(::Logger::INFO, 'my message', 'my prog')
-      log_content.rewind
-      expect(log_content.read).to match(/INFO -- my prog: my message$/)
+    context 'when given message' do
+      context 'when given progname' do
+        context 'when given block' do
+          it 'add log message containing level, message, and progname to log ignoring the block' do
+            log_content = StringIO.new
+            logger = ::Logger.new(log_content)
+            optional_logger = OptionalLogger::Logger.new(logger)
+            optional_logger.add(::Logger::INFO, 'my message', 'my prog') { 'some ignored block message' }
+            log_content.rewind
+            expect(log_content.read).to match(/INFO -- my prog: my message$/)
+          end
+        end
+
+        context 'when NOT given block' do
+          it 'add log message containing level, message, and progname to the log ' do
+            log_content = StringIO.new
+            logger = ::Logger.new(log_content)
+            optional_logger = OptionalLogger::Logger.new(logger)
+            optional_logger.add(::Logger::INFO, 'my message', 'my prog')
+            log_content.rewind
+            expect(log_content.read).to match(/INFO -- my prog: my message$/)
+          end
+        end
+      end
+
+      context 'when NOT given progname' do
+        context 'when given block' do
+          it 'add log message containing level, and message to log ignoring the block' do
+            log_content = StringIO.new
+            logger = ::Logger.new(log_content)
+            optional_logger = OptionalLogger::Logger.new(logger)
+            optional_logger.add(::Logger::INFO, 'my message') { 'some ignored block message' }
+            log_content.rewind
+            expect(log_content.read).to match(/INFO -- : my message$/)
+          end
+        end
+
+        context 'when NOT given block' do
+          it 'add log message containing level, and message to log' do
+            log_content = StringIO.new
+            logger = ::Logger.new(log_content)
+            optional_logger = OptionalLogger::Logger.new(logger)
+            optional_logger.add(::Logger::INFO, 'my message')
+            log_content.rewind
+            expect(log_content.read).to match(/INFO -- : my message$/)
+          end
+        end
+      end
+    end
+
+    context 'when message is nil' do
+      context 'when given progname' do
+        context 'when given block' do
+          it 'add log message containing level, block provided message, and progname to log' do
+            log_content = StringIO.new
+            logger = ::Logger.new(log_content)
+            optional_logger = OptionalLogger::Logger.new(logger)
+            optional_logger.add(::Logger::INFO, nil, 'my prog') { 'some block message' }
+            log_content.rewind
+            expect(log_content.read).to match(/INFO -- my prog: some block message$/)
+          end
+        end
+
+        context 'when NOT given block' do
+          it 'add log message containing level, and progname as the message to log' do
+            log_content = StringIO.new
+            logger = ::Logger.new(log_content)
+            optional_logger = OptionalLogger::Logger.new(logger)
+            optional_logger.add(::Logger::INFO, nil, 'my prog')
+            log_content.rewind
+            expect(log_content.read).to match(/INFO -- : my prog$/)
+          end
+        end
+      end
+
+      context 'when progname is nil' do
+        context 'when given block' do
+          it 'add log message containing level, and block yielded message to log' do
+            log_content = StringIO.new
+            logger = ::Logger.new(log_content)
+            optional_logger = OptionalLogger::Logger.new(logger)
+            optional_logger.add(::Logger::INFO, nil, nil) { 'some block message' }
+            log_content.rewind
+            expect(log_content.read).to match(/INFO -- : some block message$/)
+          end
+        end
+      end
     end
   end
 
@@ -29,7 +109,7 @@ describe OptionalLogger do
 
   describe '#info' do
     context 'when given a block' do
-      context 'when given progname' do
+      context 'when given message_or_progname' do
         it 'logs an info severity level message' do
           log_content = StringIO.new
           message = 'my test message'
@@ -42,7 +122,7 @@ describe OptionalLogger do
         end
       end
 
-      context 'when NOT given progname' do
+      context 'when NOT given message_or_progname' do
         it 'logs an info severity level message' do
           log_content = StringIO.new
           message = 'my test message'
@@ -57,20 +137,22 @@ describe OptionalLogger do
     end
 
     context 'when not given a block' do
-      it 'logs an info severity level message' do
-        log_content = StringIO.new
-        logger = ::Logger.new(log_content)
-        optional_logger = OptionalLogger::Logger.new(logger)
-        optional_logger.info('my message')
-        log_content.rewind
-        expect(log_content.read).to match(/INFO -- : my message$/)
+      context 'when given a message_or_progname' do
+        it 'logs an info severity level message' do
+          log_content = StringIO.new
+          logger = ::Logger.new(log_content)
+          optional_logger = OptionalLogger::Logger.new(logger)
+          optional_logger.info('my message')
+          log_content.rewind
+          expect(log_content.read).to match(/INFO -- : my message$/)
+        end
       end
     end
   end
 
   describe '#warn' do
     context 'when given a block' do
-      context 'when given progname' do
+      context 'when given message_or_progname' do
         it 'logs an warn severity level message' do
           log_content = StringIO.new
           message = 'my test message'
@@ -83,7 +165,7 @@ describe OptionalLogger do
         end
       end
 
-      context 'when NOT given progname' do
+      context 'when NOT given message_or_progname' do
         it 'logs an warn severity level message' do
           log_content = StringIO.new
           message = 'my test message'
@@ -98,20 +180,22 @@ describe OptionalLogger do
     end
 
     context 'when not given a block' do
-      it 'logs an warn severity level message' do
-        log_content = StringIO.new
-        logger = ::Logger.new(log_content)
-        optional_logger = OptionalLogger::Logger.new(logger)
-        optional_logger.warn('my message')
-        log_content.rewind
-        expect(log_content.read).to match(/WARN -- : my message$/)
+      context 'when given a message_or_progname' do
+        it 'logs an warn severity level message' do
+          log_content = StringIO.new
+          logger = ::Logger.new(log_content)
+          optional_logger = OptionalLogger::Logger.new(logger)
+          optional_logger.warn('my message')
+          log_content.rewind
+          expect(log_content.read).to match(/WARN -- : my message$/)
+        end
       end
     end
   end
 
   describe '#debug' do
     context 'when given a block' do
-      context 'when given progname' do
+      context 'when given message_or_progname' do
         it 'logs an debug severity level message' do
           log_content = StringIO.new
           message = 'my test message'
@@ -124,7 +208,7 @@ describe OptionalLogger do
         end
       end
 
-      context 'when NOT given progname' do
+      context 'when NOT given message_or_progname' do
         it 'logs an debug severity level message' do
           log_content = StringIO.new
           message = 'my test message'
@@ -139,20 +223,22 @@ describe OptionalLogger do
     end
 
     context 'when not given a block' do
-      it 'logs an debug severity level message' do
-        log_content = StringIO.new
-        logger = ::Logger.new(log_content)
-        optional_logger = OptionalLogger::Logger.new(logger)
-        optional_logger.debug('my message')
-        log_content.rewind
-        expect(log_content.read).to match(/DEBUG -- : my message$/)
+      context 'when given a message_or_progname' do
+        it 'logs an debug severity level message' do
+          log_content = StringIO.new
+          logger = ::Logger.new(log_content)
+          optional_logger = OptionalLogger::Logger.new(logger)
+          optional_logger.debug('my message')
+          log_content.rewind
+          expect(log_content.read).to match(/DEBUG -- : my message$/)
+        end
       end
     end
   end
 
   describe '#error' do
     context 'when given a block' do
-      context 'when given progname' do
+      context 'when given message_or_progname' do
         it 'logs an error severity level message' do
           log_content = StringIO.new
           message = 'my test message'
@@ -165,7 +251,7 @@ describe OptionalLogger do
         end
       end
 
-      context 'when NOT given progname' do
+      context 'when NOT given message_or_progname' do
         it 'logs an error severity level message' do
           log_content = StringIO.new
           message = 'my test message'
@@ -180,20 +266,22 @@ describe OptionalLogger do
     end
 
     context 'when not given a block' do
-      it 'logs an error severity level message' do
-        log_content = StringIO.new
-        logger = ::Logger.new(log_content)
-        optional_logger = OptionalLogger::Logger.new(logger)
-        optional_logger.error('my message')
-        log_content.rewind
-        expect(log_content.read).to match(/ERROR -- : my message$/)
+      context 'when given a message_or_progname' do
+        it 'logs an error severity level message' do
+          log_content = StringIO.new
+          logger = ::Logger.new(log_content)
+          optional_logger = OptionalLogger::Logger.new(logger)
+          optional_logger.error('my message')
+          log_content.rewind
+          expect(log_content.read).to match(/ERROR -- : my message$/)
+        end
       end
     end
   end
 
   describe '#fatal' do
     context 'when given a block' do
-      context 'when given progname' do
+      context 'when given message_or_progname' do
         it 'logs an fatal severity level message' do
           log_content = StringIO.new
           message = 'my test message'
@@ -206,7 +294,7 @@ describe OptionalLogger do
         end
       end
 
-      context 'when NOT given progname' do
+      context 'when NOT given message_or_progname' do
         it 'logs an fatal severity level message' do
           log_content = StringIO.new
           message = 'my test message'
@@ -221,20 +309,22 @@ describe OptionalLogger do
     end
 
     context 'when not given a block' do
-      it 'logs an fatal severity level message' do
-        log_content = StringIO.new
-        logger = ::Logger.new(log_content)
-        optional_logger = OptionalLogger::Logger.new(logger)
-        optional_logger.fatal('my message')
-        log_content.rewind
-        expect(log_content.read).to match(/FATAL -- : my message$/)
+      context 'when given a message_or_progname' do
+        it 'logs an fatal severity level message' do
+          log_content = StringIO.new
+          logger = ::Logger.new(log_content)
+          optional_logger = OptionalLogger::Logger.new(logger)
+          optional_logger.fatal('my message')
+          log_content.rewind
+          expect(log_content.read).to match(/FATAL -- : my message$/)
+        end
       end
     end
   end
 
   describe '#unknown' do
     context 'when given a block' do
-      context 'when given progname' do
+      context 'when given message_or_progname' do
         it 'logs an unknown severity level message' do
           log_content = StringIO.new
           message = 'my test message'
@@ -247,7 +337,7 @@ describe OptionalLogger do
         end
       end
 
-      context 'when NOT given progname' do
+      context 'when NOT given message_or_progname' do
         it 'logs an unknown severity level message' do
           log_content = StringIO.new
           message = 'my test message'
@@ -262,13 +352,15 @@ describe OptionalLogger do
     end
 
     context 'when not given a block' do
-      it 'logs an unknown severity level message' do
-        log_content = StringIO.new
-        logger = ::Logger.new(log_content)
-        optional_logger = OptionalLogger::Logger.new(logger)
-        optional_logger.unknown('my message')
-        log_content.rewind
-        expect(log_content.read).to match(/ANY -- : my message$/)
+      context 'when given message_or_progname' do
+        it 'logs an unknown severity level message' do
+          log_content = StringIO.new
+          logger = ::Logger.new(log_content)
+          optional_logger = OptionalLogger::Logger.new(logger)
+          optional_logger.unknown('my message')
+          log_content.rewind
+          expect(log_content.read).to match(/ANY -- : my message$/)
+        end
       end
     end
   end


### PR DESCRIPTION
This PR includes the basic optional logger and the following methods.
- `add`
- `log`
- `info`
- `warn`
- `debug`
- `error`
- `fatal`
- `unknown`
