### PR TITLE
Add level introspection methods

### DIFF
--- a/lib/optional_logger/logger.rb
+++ b/lib/optional_logger/logger.rb
@@ -58,5 +58,10 @@ module OptionalLogger
       return @logger.fatal? if @logger
       false
     end
+
+    def error?
+      return @logger.error? if @logger
+      false
+    end
   end
 end

--- a/lib/optional_logger/logger.rb
+++ b/lib/optional_logger/logger.rb
@@ -48,5 +48,10 @@ module OptionalLogger
       return @logger.warn? if @logger
       false
     end
+
+    def debug?
+      return @logger.debug? if @logger
+      false
+    end
   end
 end

--- a/lib/optional_logger/logger.rb
+++ b/lib/optional_logger/logger.rb
@@ -41,7 +41,12 @@ module OptionalLogger
 
     def info?
       return @logger.info? if @logger
-      return false
+      false
+    end
+
+    def warn?
+      return @logger.warn? if @logger
+      false
     end
   end
 end

--- a/lib/optional_logger/logger.rb
+++ b/lib/optional_logger/logger.rb
@@ -38,5 +38,10 @@ module OptionalLogger
     def unknown(progname_or_message = nil, &block)
       add(::Logger::UNKNOWN, nil, progname_or_message, &block)
     end
+
+    def info?
+      return @logger.info? if @logger
+      return false
+    end
   end
 end

--- a/lib/optional_logger/logger.rb
+++ b/lib/optional_logger/logger.rb
@@ -53,5 +53,10 @@ module OptionalLogger
       return @logger.debug? if @logger
       false
     end
+
+    def fatal?
+      return @logger.fatal? if @logger
+      false
+    end
   end
 end

--- a/spec/optional_logger/logger_spec.rb
+++ b/spec/optional_logger/logger_spec.rb
@@ -224,4 +224,26 @@ RSpec.describe OptionalLogger::Logger do
       end
     end
   end
+
+  describe '#fatal?' do
+    context 'when logger present' do
+      let(:logger) { double('logger') }
+      subject { described_class.new(logger) }
+
+      it 'delegates to the #fatal? method on the logger' do
+        rv = double('return value')
+        allow(logger).to receive(:fatal?).and_return(rv)
+        expect(subject.fatal?).to eq(rv)
+      end
+    end
+
+    context 'when logger NOT present' do
+      let(:logger) { nil }
+      subject { described_class.new(logger) }
+
+      it 'returns false' do
+        expect(subject.fatal?).to eq(false)
+      end
+    end
+  end
 end

--- a/spec/optional_logger/logger_spec.rb
+++ b/spec/optional_logger/logger_spec.rb
@@ -202,4 +202,26 @@ RSpec.describe OptionalLogger::Logger do
       end
     end
   end
+
+  describe '#debug?' do
+    context 'when logger present' do
+      let(:logger) { double('logger') }
+      subject { described_class.new(logger) }
+
+      it 'delegates to the #debug? method on the logger' do
+        rv = double('return value')
+        allow(logger).to receive(:debug?).and_return(rv)
+        expect(subject.debug?).to eq(rv)
+      end
+    end
+
+    context 'when logger NOT present' do
+      let(:logger) { nil }
+      subject { described_class.new(logger) }
+
+      it 'returns false' do
+        expect(subject.debug?).to eq(false)
+      end
+    end
+  end
 end

--- a/spec/optional_logger/logger_spec.rb
+++ b/spec/optional_logger/logger_spec.rb
@@ -180,4 +180,26 @@ RSpec.describe OptionalLogger::Logger do
       end
     end
   end
+
+  describe '#warn?' do
+    context 'when logger present' do
+      let(:logger) { double('logger') }
+      subject { described_class.new(logger) }
+
+      it 'delegates to the #warn? method on the logger' do
+        rv = double('return value')
+        allow(logger).to receive(:warn?).and_return(rv)
+        expect(subject.warn?).to eq(rv)
+      end
+    end
+
+    context 'when logger NOT present' do
+      let(:logger) { nil }
+      subject { described_class.new(logger) }
+
+      it 'returns false' do
+        expect(subject.warn?).to eq(false)
+      end
+    end
+  end
 end

--- a/spec/optional_logger/logger_spec.rb
+++ b/spec/optional_logger/logger_spec.rb
@@ -158,4 +158,26 @@ RSpec.describe OptionalLogger::Logger do
       subject.unknown(message, &block)
     end
   end
+
+  describe '#info?' do
+    context 'when logger present' do
+      let(:logger) { double('logger') }
+      subject { described_class.new(logger) }
+
+      it 'delegates to the #info? method on the logger' do
+        rv = double('return value')
+        allow(logger).to receive(:info?).and_return(rv)
+        expect(subject.info?).to eq(rv)
+      end
+    end
+
+    context 'when logger NOT present' do
+      let(:logger) { nil }
+      subject { described_class.new(logger) }
+
+      it 'returns false' do
+        expect(subject.info?).to eq(false)
+      end
+    end
+  end
 end

--- a/spec/optional_logger/logger_spec.rb
+++ b/spec/optional_logger/logger_spec.rb
@@ -246,4 +246,26 @@ RSpec.describe OptionalLogger::Logger do
       end
     end
   end
+
+  describe '#error?' do
+    context 'when logger present' do
+      let(:logger) { double('logger') }
+      subject { described_class.new(logger) }
+
+      it 'delegates to the #error? method on the logger' do
+        rv = double('return value')
+        allow(logger).to receive(:error?).and_return(rv)
+        expect(subject.error?).to eq(rv)
+      end
+    end
+
+    context 'when logger NOT present' do
+      let(:logger) { nil }
+      subject { described_class.new(logger) }
+
+      it 'returns false' do
+        expect(subject.error?).to eq(false)
+      end
+    end
+  end
 end

--- a/spec/optional_logger_spec.rb
+++ b/spec/optional_logger_spec.rb
@@ -415,4 +415,37 @@ describe OptionalLogger do
       end
     end
   end
+
+  describe '#warn?' do
+    context 'when logger present' do
+      context 'when current severity level allows for warn messages' do
+        it 'returns true' do
+          log_content = StringIO.new
+          logger = ::Logger.new(log_content)
+          logger.level = ::Logger::INFO
+          optional_logger = OptionalLogger::Logger.new(logger)
+
+          expect(optional_logger.warn?).to eq(true)
+        end
+      end
+
+      context 'when the current severity does not allow for warn messages' do
+        it 'returns false' do
+          log_content = StringIO.new
+          logger = ::Logger.new(log_content)
+          logger.level = ::Logger::UNKNOWN
+          optional_logger = OptionalLogger::Logger.new(logger)
+
+          expect(optional_logger.warn?).to eq(false)
+        end
+      end
+    end
+
+    context 'when logger NOT present' do
+      it 'returns false' do
+        optional_logger = OptionalLogger::Logger.new(nil)
+        expect(optional_logger.warn?).to eq(false)
+      end
+    end
+  end
 end

--- a/spec/optional_logger_spec.rb
+++ b/spec/optional_logger_spec.rb
@@ -514,4 +514,37 @@ describe OptionalLogger do
       end
     end
   end
+
+  describe '#error?' do
+    context 'when logger present' do
+      context 'when current severity level allows for error messages' do
+        it 'returns true' do
+          log_content = StringIO.new
+          logger = ::Logger.new(log_content)
+          logger.level = ::Logger::ERROR
+          optional_logger = OptionalLogger::Logger.new(logger)
+
+          expect(optional_logger.error?).to eq(true)
+        end
+      end
+
+      context 'when the current severity does not allow for error messages' do
+        it 'returns false' do
+          log_content = StringIO.new
+          logger = ::Logger.new(log_content)
+          logger.level = ::Logger::UNKNOWN
+          optional_logger = OptionalLogger::Logger.new(logger)
+
+          expect(optional_logger.error?).to eq(false)
+        end
+      end
+    end
+
+    context 'when logger NOT present' do
+      it 'returns false' do
+        optional_logger = OptionalLogger::Logger.new(nil)
+        expect(optional_logger.error?).to eq(false)
+      end
+    end
+  end
 end

--- a/spec/optional_logger_spec.rb
+++ b/spec/optional_logger_spec.rb
@@ -481,4 +481,37 @@ describe OptionalLogger do
       end
     end
   end
+
+  describe '#fatal?' do
+    context 'when logger present' do
+      context 'when current severity level allows for fatal messages' do
+        it 'returns true' do
+          log_content = StringIO.new
+          logger = ::Logger.new(log_content)
+          logger.level = ::Logger::FATAL
+          optional_logger = OptionalLogger::Logger.new(logger)
+
+          expect(optional_logger.fatal?).to eq(true)
+        end
+      end
+
+      context 'when the current severity does not allow for fatal messages' do
+        it 'returns false' do
+          log_content = StringIO.new
+          logger = ::Logger.new(log_content)
+          logger.level = ::Logger::UNKNOWN
+          optional_logger = OptionalLogger::Logger.new(logger)
+
+          expect(optional_logger.fatal?).to eq(false)
+        end
+      end
+    end
+
+    context 'when logger NOT present' do
+      it 'returns false' do
+        optional_logger = OptionalLogger::Logger.new(nil)
+        expect(optional_logger.fatal?).to eq(false)
+      end
+    end
+  end
 end

--- a/spec/optional_logger_spec.rb
+++ b/spec/optional_logger_spec.rb
@@ -422,7 +422,7 @@ describe OptionalLogger do
         it 'returns true' do
           log_content = StringIO.new
           logger = ::Logger.new(log_content)
-          logger.level = ::Logger::INFO
+          logger.level = ::Logger::WARN
           optional_logger = OptionalLogger::Logger.new(logger)
 
           expect(optional_logger.warn?).to eq(true)

--- a/spec/optional_logger_spec.rb
+++ b/spec/optional_logger_spec.rb
@@ -448,4 +448,37 @@ describe OptionalLogger do
       end
     end
   end
+
+  describe '#debug?' do
+    context 'when logger present' do
+      context 'when current severity level allows for debug messages' do
+        it 'returns true' do
+          log_content = StringIO.new
+          logger = ::Logger.new(log_content)
+          logger.level = ::Logger::DEBUG
+          optional_logger = OptionalLogger::Logger.new(logger)
+
+          expect(optional_logger.debug?).to eq(true)
+        end
+      end
+
+      context 'when the current severity does not allow for debug messages' do
+        it 'returns false' do
+          log_content = StringIO.new
+          logger = ::Logger.new(log_content)
+          logger.level = ::Logger::UNKNOWN
+          optional_logger = OptionalLogger::Logger.new(logger)
+
+          expect(optional_logger.debug?).to eq(false)
+        end
+      end
+    end
+
+    context 'when logger NOT present' do
+      it 'returns false' do
+        optional_logger = OptionalLogger::Logger.new(nil)
+        expect(optional_logger.debug?).to eq(false)
+      end
+    end
+  end
 end

--- a/spec/optional_logger_spec.rb
+++ b/spec/optional_logger_spec.rb
@@ -382,4 +382,37 @@ describe OptionalLogger do
       end
     end
   end
+
+  describe '#info?' do
+    context 'when logger present' do
+      context 'when current severity level allows for info messages' do
+        it 'returns true' do
+          log_content = StringIO.new
+          logger = ::Logger.new(log_content)
+          logger.level = ::Logger::INFO
+          optional_logger = OptionalLogger::Logger.new(logger)
+
+          expect(optional_logger.info?).to eq(true)
+        end
+      end
+
+      context 'when the current severity does not allow for info messages' do
+        it 'returns false' do
+          log_content = StringIO.new
+          logger = ::Logger.new(log_content)
+          logger.level = ::Logger::UNKNOWN
+          optional_logger = OptionalLogger::Logger.new(logger)
+
+          expect(optional_logger.info?).to eq(false)
+        end
+      end
+    end
+
+    context 'when logger NOT present' do
+      it 'returns false' do
+        optional_logger = OptionalLogger::Logger.new(nil)
+        expect(optional_logger.info?).to eq(false)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Add all of the level introspection methods so that we more closely match the standard ruby logger interface as well as allow our users to check if the given levels are supported given the loggers current configuration.
