### PR TITLE
Add logger management

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,34 @@ logger.log(Logger::FATAL, "some message", "Program Name")
 **Note:** You don't have to worry about setting up or cleaning up after the
 logger as it is managed by the application that is using your library.
 
+### Logger Management
+
+We also provide a small module to aid with logger management within your gem if
+you don't want to write your own logger management using the core logger
+provided above. The following is an example of how might use it if you had a gem
+called `my_foo_gem`.
+
+```ruby
+require 'optional_logger'
+
+module MyFooGem
+  include OptionalLogger::LoggerManagement
+end
+```
+
+The above would enable consumers of your library to set the logger as follows.
+
+```ruby
+MyFooGem.logger(some_application_logger)
+```
+
+It also enables you to access an `OptionalLogger::Logger` instance that wraps
+the application logger they provided within your gem as follows.
+
+```ruby
+MyFooGem.logger # => the optional logger wrapping some_application_logger
+```
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run

--- a/lib/optional_logger.rb
+++ b/lib/optional_logger.rb
@@ -1,5 +1,6 @@
 require 'optional_logger/version'
 require 'optional_logger/logger'
+require 'optional_logger/logger_management'
 
 # Top-level namespace for a library providing an optional logger and supporting
 # functionality around it

--- a/lib/optional_logger/logger_management.rb
+++ b/lib/optional_logger/logger_management.rb
@@ -1,0 +1,20 @@
+require 'optional_logger'
+
+module OptionalLogger
+  module LoggerManagement
+    def self.included(base)
+      base.extend(ClassMethods)
+    end
+
+    module ClassMethods
+      def logger(logger = nil)
+        if logger.nil?
+          @logger = OptionalLogger::Logger.new(nil) if @logger.nil?
+        else
+          @logger = OptionalLogger::Logger.new(logger)
+        end
+        return @logger
+      end
+    end
+  end
+end

--- a/lib/optional_logger/logger_management.rb
+++ b/lib/optional_logger/logger_management.rb
@@ -8,12 +8,8 @@ module OptionalLogger
 
     module ClassMethods
       def logger(logger = nil)
-        if logger.nil?
-          @logger = OptionalLogger::Logger.new(nil) if @logger.nil?
-        else
-          @logger = OptionalLogger::Logger.new(logger)
-        end
-        return @logger
+        return @logger if @logger && logger.nil?
+        @logger = OptionalLogger::Logger.new(logger)
       end
     end
   end

--- a/spec/optional_logger/logger_management_spec.rb
+++ b/spec/optional_logger/logger_management_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe OptionalLogger::LoggerManagement do
     context 'when given a logger' do
       context 'when the logger has NOT previously been set' do
         it 'wraps given logger in an optional logger' do
-          klass = Class.new do
+          klass = Module.new do
             include OptionalLogger::LoggerManagement
           end
 
@@ -15,7 +15,7 @@ RSpec.describe OptionalLogger::LoggerManagement do
         end
 
         it 'stores the optional logger' do
-          klass = Class.new do
+          klass = Module.new do
             include OptionalLogger::LoggerManagement
           end
 
@@ -30,7 +30,7 @@ RSpec.describe OptionalLogger::LoggerManagement do
 
       context 'when the logger HAS previously been set' do
         it 'wraps given logger in an optional logger' do
-          klass = Class.new do
+          klass = Module.new do
             include OptionalLogger::LoggerManagement
           end
 
@@ -42,7 +42,7 @@ RSpec.describe OptionalLogger::LoggerManagement do
         end
 
         it 'stores the optional logger' do
-          klass = Class.new do
+          klass = Module.new do
             include OptionalLogger::LoggerManagement
           end
 
@@ -61,7 +61,7 @@ RSpec.describe OptionalLogger::LoggerManagement do
     context 'when not given a logger' do
       context 'when the logger has previously been set' do
         it 'returns the optional logger containing the previously set logger' do
-          klass = Class.new do
+          klass = Module.new do
             include OptionalLogger::LoggerManagement
           end
 
@@ -74,7 +74,7 @@ RSpec.describe OptionalLogger::LoggerManagement do
 
       context 'when it has NOT previously been set' do
         it 'returns the optional logger' do
-          klass = Class.new do
+          klass = Module.new do
             include OptionalLogger::LoggerManagement
           end
 

--- a/spec/optional_logger/logger_management_spec.rb
+++ b/spec/optional_logger/logger_management_spec.rb
@@ -3,27 +3,58 @@ require 'spec_helper'
 RSpec.describe OptionalLogger::LoggerManagement do
   describe '.logger' do
     context 'when given a logger' do
-      it 'wraps given logger in an optional logger' do
-        klass = Class.new do
-          include OptionalLogger::LoggerManagement
+      context 'when the logger has NOT previously been set' do
+        it 'wraps given logger in an optional logger' do
+          klass = Class.new do
+            include OptionalLogger::LoggerManagement
+          end
+
+          logger = double('logger')
+          expect(OptionalLogger::Logger).to receive(:new).with(logger)
+          klass.logger(logger)
         end
 
-        logger = double('logger')
-        expect(OptionalLogger::Logger).to receive(:new).with(logger)
-        rv = klass.logger(logger)
+        it 'stores the optional logger' do
+          klass = Class.new do
+            include OptionalLogger::LoggerManagement
+          end
+
+          logger = double('logger')
+          optional_logger = double('optional_logger')
+          allow(OptionalLogger::Logger).to receive(:new).with(logger).and_return(optional_logger)
+          rv = klass.logger(logger)
+          expect(klass.instance_variable_get(:@logger)).to eq(optional_logger)
+          expect(rv).to eq(optional_logger)
+        end
       end
 
-      it 'stores the optional logger' do
-        klass = Class.new do
-          include OptionalLogger::LoggerManagement
+      context 'when the logger HAS previously been set' do
+        it 'wraps given logger in an optional logger' do
+          klass = Class.new do
+            include OptionalLogger::LoggerManagement
+          end
+
+          old_logger = double('old logger')
+          logger = double('logger')
+          klass.instance_variable_set(:@logger, old_logger)
+          expect(OptionalLogger::Logger).to receive(:new).with(logger)
+          klass.logger(logger)
         end
 
-        logger = double('logger')
-        optional_logger = double('optional_logger')
-        allow(OptionalLogger::Logger).to receive(:new).with(logger).and_return(optional_logger)
-        rv = klass.logger(logger)
-        expect(klass.instance_variable_get(:@logger)).to eq(optional_logger)
-        expect(rv).to eq(optional_logger)
+        it 'stores the optional logger' do
+          klass = Class.new do
+            include OptionalLogger::LoggerManagement
+          end
+
+          old_logger = double('old logger')
+          logger = double('logger')
+          optional_logger = double('optional_logger')
+          klass.instance_variable_set(:@logger, old_logger)
+          allow(OptionalLogger::Logger).to receive(:new).with(logger).and_return(optional_logger)
+          rv = klass.logger(logger)
+          expect(klass.instance_variable_get(:@logger)).to eq(optional_logger)
+          expect(rv).to eq(optional_logger)
+        end
       end
     end
 

--- a/spec/optional_logger/logger_management_spec.rb
+++ b/spec/optional_logger/logger_management_spec.rb
@@ -1,0 +1,56 @@
+require 'spec_helper'
+
+RSpec.describe OptionalLogger::LoggerManagement do
+  describe '.logger' do
+    context 'when given a logger' do
+      it 'wraps given logger in an optional logger' do
+        klass = Class.new do
+          include OptionalLogger::LoggerManagement
+        end
+
+        logger = double('logger')
+        expect(OptionalLogger::Logger).to receive(:new).with(logger)
+        rv = klass.logger(logger)
+      end
+
+      it 'stores the optional logger' do
+        klass = Class.new do
+          include OptionalLogger::LoggerManagement
+        end
+
+        logger = double('logger')
+        optional_logger = double('optional_logger')
+        allow(OptionalLogger::Logger).to receive(:new).with(logger).and_return(optional_logger)
+        rv = klass.logger(logger)
+        expect(klass.instance_variable_get(:@logger)).to eq(optional_logger)
+        expect(rv).to eq(optional_logger)
+      end
+    end
+
+    context 'when not given a logger' do
+      context 'when the logger has previously been set' do
+        it 'returns the optional logger containing the previously set logger' do
+          klass = Class.new do
+            include OptionalLogger::LoggerManagement
+          end
+
+          logger = double('logger')
+          klass.logger(logger)
+          expect(klass.logger).to be_a(OptionalLogger::Logger)
+          expect(klass.logger.wrapped_logger).to eq(logger)
+        end
+      end
+
+      context 'when it has NOT previously been set' do
+        it 'returns the optional logger' do
+          klass = Class.new do
+            include OptionalLogger::LoggerManagement
+          end
+
+          expect(klass.logger).to be_a(OptionalLogger::Logger)
+          expect(klass.logger.wrapped_logger).to be_nil
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Why you made the change:

I did this so that if people wanted to use the provided logger instance
management within their gem. They could, rather than having to
completely rewrite it in every gem that they use.
