### PR TITLE
Add logger management instance support

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,14 +95,18 @@ logger as it is managed by the application that is using your library.
 
 We also provide a small module to aid with logger management within your gem if
 you don't want to write your own logger management using the core logger
-provided above. The following is an example of how might use it if you had a gem
-called `my_foo_gem`.
+provided above. The following are a couple examples of how you might use it.
+
+#### Module/Class Level
+
+If you want to provide the logger interface at a Module/Class level. You would
+do the following.
 
 ```ruby
 require 'optional_logger'
 
 module MyFooGem
-  include OptionalLogger::LoggerManagement
+  extend OptionalLogger::LoggerManagement
 end
 ```
 
@@ -117,6 +121,41 @@ the application logger they provided within your gem as follows.
 
 ```ruby
 MyFooGem.logger # => the optional logger wrapping some_application_logger
+
+# or if you are inside the module
+
+self.logger # or simply logger
+```
+
+#### Instance Level
+
+If you want to provide the logger interface at an instance level. You would do
+the following.
+
+```ruby
+require 'optional_logger'
+
+module MyClass
+  include OptionalLogger::LoggerManagement
+end
+```
+
+The above would enable consumers of your library to set the logger as follows.
+
+```ruby
+obj = MyClass.new
+obj.logger(some_application_logger)
+```
+
+It also enables you to access an `OptionalLogger::Logger` instance that wraps
+the application logger they provided within your gem as follows.
+
+```ruby
+obj.logger # => the optional logger wrapping some_application_logger
+
+# or if you are inside the class
+
+self.logger # or simply logger
 ```
 
 ## Development

--- a/lib/optional_logger/logger_management.rb
+++ b/lib/optional_logger/logger_management.rb
@@ -2,15 +2,9 @@ require 'optional_logger'
 
 module OptionalLogger
   module LoggerManagement
-    def self.included(base)
-      base.extend(ClassMethods)
-    end
-
-    module ClassMethods
-      def logger(logger = nil)
-        return @logger if @logger && logger.nil?
-        @logger = OptionalLogger::Logger.new(logger)
-      end
+    def logger(logger = nil)
+      return @logger if @logger && logger.nil?
+      @logger = OptionalLogger::Logger.new(logger)
     end
   end
 end

--- a/spec/optional_logger/logger_management_spec.rb
+++ b/spec/optional_logger/logger_management_spec.rb
@@ -2,84 +2,177 @@ require 'spec_helper'
 
 RSpec.describe OptionalLogger::LoggerManagement do
   describe '.logger' do
-    context 'when given a logger' do
-      context 'when the logger has NOT previously been set' do
-        it 'wraps given logger in an optional logger' do
-          klass = Module.new do
-            include OptionalLogger::LoggerManagement
+    describe 'class level interface' do
+      context 'when given a logger' do
+        context 'when the logger has NOT previously been set' do
+          it 'wraps given logger in an optional logger' do
+            klass = Module.new do
+              extend OptionalLogger::LoggerManagement
+            end
+
+            logger = double('logger')
+            expect(OptionalLogger::Logger).to receive(:new).with(logger)
+            klass.logger(logger)
           end
 
-          logger = double('logger')
-          expect(OptionalLogger::Logger).to receive(:new).with(logger)
-          klass.logger(logger)
+          it 'stores and returns the optional logger' do
+            klass = Module.new do
+              extend OptionalLogger::LoggerManagement
+            end
+
+            logger = double('logger')
+            optional_logger = double('optional_logger')
+            allow(OptionalLogger::Logger).to receive(:new).with(logger).and_return(optional_logger)
+            rv = klass.logger(logger)
+            expect(klass.instance_variable_get(:@logger)).to eq(optional_logger)
+            expect(rv).to eq(optional_logger)
+          end
         end
 
-        it 'stores the optional logger' do
-          klass = Module.new do
-            include OptionalLogger::LoggerManagement
+        context 'when the logger HAS previously been set' do
+          it 'wraps given logger in an optional logger' do
+            klass = Module.new do
+              extend OptionalLogger::LoggerManagement
+            end
+
+            old_logger = double('old logger')
+            logger = double('logger')
+            klass.instance_variable_set(:@logger, old_logger)
+            expect(OptionalLogger::Logger).to receive(:new).with(logger)
+            klass.logger(logger)
           end
 
-          logger = double('logger')
-          optional_logger = double('optional_logger')
-          allow(OptionalLogger::Logger).to receive(:new).with(logger).and_return(optional_logger)
-          rv = klass.logger(logger)
-          expect(klass.instance_variable_get(:@logger)).to eq(optional_logger)
-          expect(rv).to eq(optional_logger)
+          it 'stores and returns the optional logger' do
+            klass = Module.new do
+              extend OptionalLogger::LoggerManagement
+            end
+
+            old_logger = double('old logger')
+            logger = double('logger')
+            optional_logger = double('optional_logger')
+            klass.instance_variable_set(:@logger, old_logger)
+            allow(OptionalLogger::Logger).to receive(:new).with(logger).and_return(optional_logger)
+            rv = klass.logger(logger)
+            expect(klass.instance_variable_get(:@logger)).to eq(optional_logger)
+            expect(rv).to eq(optional_logger)
+          end
         end
       end
 
-      context 'when the logger HAS previously been set' do
-        it 'wraps given logger in an optional logger' do
-          klass = Module.new do
-            include OptionalLogger::LoggerManagement
-          end
+      context 'when not given a logger' do
+        context 'when the logger has previously been set' do
+          it 'returns the optional logger containing the previously set logger' do
+            klass = Module.new do
+              extend OptionalLogger::LoggerManagement
+            end
 
-          old_logger = double('old logger')
-          logger = double('logger')
-          klass.instance_variable_set(:@logger, old_logger)
-          expect(OptionalLogger::Logger).to receive(:new).with(logger)
-          klass.logger(logger)
+            logger = double('logger')
+            klass.logger(logger)
+            expect(klass.logger).to be_a(OptionalLogger::Logger)
+            expect(klass.logger.wrapped_logger).to eq(logger)
+          end
         end
 
-        it 'stores the optional logger' do
-          klass = Module.new do
-            include OptionalLogger::LoggerManagement
-          end
+        context 'when it has NOT previously been set' do
+          it 'returns the optional logger wrapping nil' do
+            klass = Module.new do
+              extend OptionalLogger::LoggerManagement
+            end
 
-          old_logger = double('old logger')
-          logger = double('logger')
-          optional_logger = double('optional_logger')
-          klass.instance_variable_set(:@logger, old_logger)
-          allow(OptionalLogger::Logger).to receive(:new).with(logger).and_return(optional_logger)
-          rv = klass.logger(logger)
-          expect(klass.instance_variable_get(:@logger)).to eq(optional_logger)
-          expect(rv).to eq(optional_logger)
+            expect(klass.logger).to be_a(OptionalLogger::Logger)
+            expect(klass.logger.wrapped_logger).to be_nil
+          end
         end
       end
     end
 
-    context 'when not given a logger' do
-      context 'when the logger has previously been set' do
-        it 'returns the optional logger containing the previously set logger' do
-          klass = Module.new do
-            include OptionalLogger::LoggerManagement
+    describe 'instance level interface' do
+      context 'when given a logger' do
+        context 'when the logger has NOT previously been set' do
+          it 'wraps given logger in an optional logger' do
+            klass = Class.new do
+              include OptionalLogger::LoggerManagement
+            end
+
+            logger = double('logger')
+            expect(OptionalLogger::Logger).to receive(:new).with(logger)
+            klass.new.logger(logger)
           end
 
-          logger = double('logger')
-          klass.logger(logger)
-          expect(klass.logger).to be_a(OptionalLogger::Logger)
-          expect(klass.logger.wrapped_logger).to eq(logger)
+          it 'stores and returns the optional logger' do
+            klass = Class.new do
+              include OptionalLogger::LoggerManagement
+            end
+
+            logger = double('logger')
+            optional_logger = double('optional_logger')
+            allow(OptionalLogger::Logger).to receive(:new).with(logger).and_return(optional_logger)
+            foo = klass.new
+            rv = foo.logger(logger)
+            expect(foo.instance_variable_get(:@logger)).to eq(optional_logger)
+            expect(rv).to eq(optional_logger)
+          end
+        end
+
+        context 'when the logger HAS previously been set' do
+          it 'wraps given logger in an optional logger' do
+            klass = Class.new do
+              include OptionalLogger::LoggerManagement
+            end
+
+            old_logger = double('old logger')
+            logger = double('logger')
+            foo = klass.new
+            foo.instance_variable_set(:@logger, old_logger)
+            expect(OptionalLogger::Logger).to receive(:new).with(logger)
+            foo.logger(logger)
+          end
+
+          it 'stores and returns the optional logger' do
+            klass = Class.new do
+              include OptionalLogger::LoggerManagement
+            end
+
+            old_logger = double('old logger')
+            logger = double('logger')
+            optional_logger = double('optional_logger')
+            foo = klass.new
+            klass.instance_variable_set(:@logger, old_logger)
+            allow(OptionalLogger::Logger).to receive(:new).with(logger).and_return(optional_logger)
+            rv = foo.logger(logger)
+            expect(foo.instance_variable_get(:@logger)).to eq(optional_logger)
+            expect(rv).to eq(optional_logger)
+          end
         end
       end
 
-      context 'when it has NOT previously been set' do
-        it 'returns the optional logger' do
-          klass = Module.new do
-            include OptionalLogger::LoggerManagement
-          end
+      context 'when not given a logger' do
+        context 'when the logger has previously been set' do
+          it 'returns the optional logger containing the previously set logger' do
+            klass = Class.new do
+              include OptionalLogger::LoggerManagement
+            end
 
-          expect(klass.logger).to be_a(OptionalLogger::Logger)
-          expect(klass.logger.wrapped_logger).to be_nil
+            logger = double('logger')
+            foo = klass.new
+            foo.logger(logger)
+
+            expect(foo.logger).to be_a(OptionalLogger::Logger)
+            expect(foo.logger.wrapped_logger).to eq(logger)
+          end
+        end
+
+        context 'when it has NOT previously been set' do
+          it 'returns the optional logger wrapping nil' do
+            klass = Class.new do
+              include OptionalLogger::LoggerManagement
+            end
+
+            foo = klass.new
+
+            expect(foo.logger).to be_a(OptionalLogger::Logger)
+            expect(foo.logger.wrapped_logger).to be_nil
+          end
         end
       end
     end


### PR DESCRIPTION
Why you made the change:

I did this so that the logger management module can be used at either
the class level using extend, or at the instance level using include.
This gives the management interface far more flexibility and allows it
to be used in the majority of situations. This is definitely a breaking
change in terms of the public API so this will result in a major version
bump. But, given our current usage is pretty small I think it is worth
it.
